### PR TITLE
Add missing template keywords

### DIFF
--- a/syntaxes/vento.tmLanguage.json
+++ b/syntaxes/vento.tmLanguage.json
@@ -33,7 +33,7 @@
       ]
     },
     "template_keyword": {
-      "match": "for|of|if|else\\s+if|else|include|set|layout|echo",
+      "match": "for|of|if|else\\s+if|else|include|set|layout|echo|function|import|export|>",
       "name": "keyword.vento"
     },
     "front_matter": {


### PR DESCRIPTION
If `function`, `import` or `export` was used before this change, syntax highlighting will not work in the subsequent code.