### PR TITLE
Show icon on files supported by the extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,11 @@
       "id": "vento",
       "aliases": ["Vento", "vento"],
       "extensions": [".vto", ".vento"],
-      "configuration": "./language-configuration.json"
+      "configuration": "./language-configuration.json",
+      "icon": {
+        "light": "./icon.svg",
+        "dark": "./icon.svg"
+      }
     }],
     "grammars": [{
       "language": "vento",


### PR DESCRIPTION
Ola,

I appreciate seeing an icon for files supported by a language extension (in the explorer, and on the edited file).

It could be great to have it for vento.

A small change in the `package.json` enables to do it.

| With icon| Without icon |
|------|---------|
| <img src="https://github.com/ventojs/vscode-vento/assets/62034725/228df2a1-620a-4fee-b5fe-74b7e5ea5cbd" width=500 > | <img src="https://github.com/ventojs/vscode-vento/assets/62034725/c08234e3-cad0-40a0-9498-276cfcbe0ed8" width=500>  
  



