### PR TITLE
ensure keywords are between word boundaries

### DIFF
--- a/syntaxes/vento.tmLanguage.json
+++ b/syntaxes/vento.tmLanguage.json
@@ -55,7 +55,7 @@
       ]
     },
     "template_keyword": {
-      "match": "for|of|if|else\\s+if|else|include|set|layout|echo|function|async\\s+function|import|from|export|await",
+      "match": "\\b(for|of|if|else\\s+if|else|include|set|layout|echo|function|async\\s+function|import|from|export|await)\\b",
       "name": "keyword.vento"
     },
     "front_matter": {


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="273" alt="image" src="https://github.com/user-attachments/assets/a0c7c836-108f-4d07-aa09-22c6ac6b9cf6"> | <img width="275" alt="image" src="https://github.com/user-attachments/assets/86b6130f-681a-4716-ac5a-fa38bac5e2b4"> |